### PR TITLE
fail when entropy length does not match expected amount

### DIFF
--- a/bip32gen
+++ b/bip32gen
@@ -14,11 +14,7 @@ def ReadInput(fname, count, is_hex):
    f = sys.stdin if fname == '-' else open(fname, 'rb')
 
    with f:
-      if count is not None:
-         n = count*2 if is_hex else count
-         data = f.read(n)
-      else:
-         data = f.read()
+      data = f.read()
 
    if is_hex:
       data = data.strip().decode('hex')
@@ -120,6 +116,8 @@ def ReadEntropy(args):
    entropy = ReadInput(args.from_file, args.amount/8, args.input_hex)
    if len(entropy) < args.amount/8:
       raise Exception("Insufficient entropy provided")
+   if len(entropy) > args.amount/8:
+      raise Exception("Entropy string longer than expected, adjust amount with -n ?")
    if args.verbose:
       src = 'stdin' if args.from_file == '-' else args.from_file
       print("Creating master key and seed using %i bits of entropy read from %s" % (args.amount, src))


### PR DESCRIPTION
In the current version bip32gen will silently truncate entropy strings longer than expected by default (128 bits). We noticed this risky behavior while using bip32gen in one of the projects I'm involved in, after a colleague noticed that the BIP32 test vectors 2 and 3 were not passed. Only later we realized that `-n 512` was necessary.

This PR raises an exception when the entropy received (through both stdin or a file) is longer than the expected amount, and suggests to the user that they may need to set the right amount using `-n`.

   